### PR TITLE
Added copy to clipboard button for the clipboard

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -129,3 +129,9 @@ $('#cliCommand').on('keydown', function (e) {
     sendCommand(e);
   }
 });
+
+function copyToClipboard(id) {
+  const textSelected = document.getElementById('card-body-' + id).innerText;
+  navigator.clipboard.writeText(textSelected);
+  return false;
+}

--- a/httpserver/static/templates/index.html
+++ b/httpserver/static/templates/index.html
@@ -256,12 +256,14 @@
                             <div class="col-md-1">
                                 <sup><a href="#" onclick="return delClipboard('{{.ID}}')"><i
                                             class="fa-solid fa-trash del_button"></i></a></sup>
+                                <sup><a href="#" onclick="return copyToClipboard('{{.ID}}')"><i
+                                    class="fa-solid fa-copy del_button"></i></a></sup>
                             </div>
                             <div class="col-md-1">
                                 <h5>{{.ID}}</h5>
                             </div>
                         </div>
-                        <div class="card-body">
+                        <div class="card-body" id="card-body-{{.ID}}">
                             <pre>{{.Content}}</pre>
                         </div>
                     </div>


### PR DESCRIPTION
Added a small button next to the delete clipboard option to copy the text to clipboard. In many occasions the text I had to copy was large and it is tiring to manually scroll across the whole view to select it.

![Screenshot 2023-06-27 at 19 51 23](https://github.com/patrickhener/goshs/assets/5909985/7f0b5c8b-b0f8-4898-aaf5-d597be6bca40)

The last return false on the copyToClipboard function is just to prevent the page from reloading, instead of passing the event and using preventDefault, since it is not needed. 
