### PR TITLE
Log bulk download requests

### DIFF
--- a/httpserver/updown.go
+++ b/httpserver/updown.go
@@ -191,5 +191,7 @@ func (fs *FileServer) bulkDownload(w http.ResponseWriter, req *http.Request) {
 	// Close Zip Writer and Flush to http.ResponseWriter
 	if err := resultZip.Close(); err != nil {
 		logger.Error(err)
+	} else {
+		logger.LogRequest(req, http.StatusOK, fs.Verbose)
 	}
 }


### PR DESCRIPTION
In the current version, bulk download requests are not logged