### PR TITLE
Implement p12 feature and leave key and cert mechanism as is

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/crypto v0.21.0
 	golang.org/x/net v0.23.0
+	software.sslmate.com/src/go-pkcs12 v0.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -46,3 +46,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
+software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/httpserver/error.go
+++ b/httpserver/error.go
@@ -71,7 +71,7 @@ func (fs *FileServer) logStart(what string) {
 				logger.Infof("SHA-256 Fingerprint: %+v\n", fs.Fingerprint256)
 				logger.Infof("SHA-1   Fingerprint: %+v\n", fs.Fingerprint1)
 			} else {
-				logger.Infof("Serving %s from %+v with ssl enabled server key: %+v, server cert: %+v\n", protocol, fs.Webroot, fs.MyKey, fs.MyCert)
+				logger.Infof("Serving %s from %+v with ssl enabled server key: %+v, server cert: %+v, server p12: %+v\n", protocol, fs.Webroot, fs.MyKey, fs.MyCert, fs.MyP12)
 				logger.Info("You provided a certificate and might want to check the fingerprint nonetheless")
 				logger.Infof("SHA-256 Fingerprint: %+v\n", fs.Fingerprint256)
 				logger.Infof("SHA-1   Fingerprint: %+v\n", fs.Fingerprint1)

--- a/httpserver/structs.go
+++ b/httpserver/structs.go
@@ -50,6 +50,7 @@ type FileServer struct {
 	LetsEncrypt    bool
 	MyKey          string
 	MyCert         string
+	MyP12          string
 	User           string
 	Pass           string
 	DropUser       string

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 	letsencrypt = false
 	myKey       = ""
 	myCert      = ""
+	myP12       = ""
 	basicAuth   = ""
 	webdav      = false
 	webdavPort  = 8001
@@ -66,6 +67,7 @@ TLS options:
   -ss,  --self-signed  Use a self-signed certificate
   -sk,  --server-key   Path to server key
   -sc,  --server-cert  Path to server certificate
+  -p12, --pkcs12       Path to server p12
   -sl,  --lets-encrypt Use Let's Encrypt as certification service
   -sld, --le-domains   Domain(s) to request from Let's Encrypt		(comma separated list)
   -sle, --le-email     Email to use with Let's Encrypt
@@ -115,6 +117,8 @@ func init() {
 	flag.StringVar(&myKey, "server-key", myKey, "server key")
 	flag.StringVar(&myCert, "sc", myCert, "server cert")
 	flag.StringVar(&myCert, "server-cert", myCert, "server cert")
+	flag.StringVar(&myP12, "p12", myP12, "server p12")
+	flag.StringVar(&myP12, "pkcs12", myP12, "server p12")
 	flag.StringVar(&basicAuth, "b", basicAuth, "basic auth")
 	flag.StringVar(&basicAuth, "basic-auth", basicAuth, "basic auth")
 	flag.BoolVar(&webdav, "w", webdav, "enable webdav")
@@ -251,6 +255,7 @@ func main() {
 		LetsEncrypt: letsencrypt,
 		MyCert:      myCert,
 		MyKey:       myKey,
+		MyP12:       myP12,
 		User:        user,
 		Pass:        pass,
 		DropUser:    dropuser,


### PR DESCRIPTION
# Issue

Tackles issue #65 

# Description

So encrypted key file I cannot make it to work. So I will leave the cert/key mechanism as is, meaning that you can use it with a no password protected key file. Or now you could use a p12 file. You can provide the password to decrypt it when starting goshs. So this is somewhat secure.
