### PR TITLE
Support installation via windows scoop package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ go get -u github.com/patrickhener/goshs
 go install github.com/patrickhener/goshs@latest
 ```
 
+## Scoop (Windows)
+
+```bash
+scoop install https://raw.githubusercontent.com/patrickhener/goshs/main/scoop/goshs.json
+```
+
 ## Build yourself
 
 Building requirements are [ugilfy-js](https://www.npmjs.com/package/uglify-js) and [sass](https://sass-lang.com/install). After installing this packages you can easily just:

--- a/scoop/goshs.json
+++ b/scoop/goshs.json
@@ -1,0 +1,29 @@
+{
+    "version": "0.4.1",
+    "description": "A SimpleHTTPServer written in Go, enhanced with features and with a nice design",
+    "homepage": "https://goshs.de",
+    "license": {
+        "identifier": "MIT",
+        "url": "https://github.com/patrickhener/goshs/blob/main/LICENSE"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/patrickhener/goshs/releases/download/v0.4.1/goshs_windows_x86_64.tar.gz",
+            "hash": "82d158e4279eb95a5a48f650fc5ab8bfd408a54b5534a5777db77217d6a8b119"
+        },
+        "32bit": {
+            "url": "https://github.com/patrickhener/goshs/releases/download/v0.4.1/goshs_windows_386.tar.gz",
+            "hash": "8d3d0d798a63049fd05f451fc5fbbd198dc1f8acfcda90ba972aa18b21ded4c2"
+        },
+        "arm64": {
+            "url": "https://github.com/patrickhener/goshs/releases/download/v0.4.1/goshs_windows_arm64.tar.gz",
+            "hash": "7ec02d780205cf6e1499000f9b61631eab0a24abb633220b6c4c9998045f37d2"
+        }
+    },
+	"bin": [
+		[
+			"goshs.exe",
+			"goshs"
+		]
+	]
+}


### PR DESCRIPTION
added the ability to install via the scoop package manager for windows (https://scoop.sh/)