### PR TITLE
Add option to disable clipboard

### DIFF
--- a/httpserver/handler.go
+++ b/httpserver/handler.go
@@ -106,8 +106,10 @@ func (fs *FileServer) earlyBreakParameters(w http.ResponseWriter, req *http.Requ
 		return true
 	}
 	if _, ok := req.URL.Query()["cbDown"]; ok {
-		fs.cbDown(w, req)
-		return true
+		if !fs.NoClipboard {
+			fs.cbDown(w, req)
+			return true
+		}
 	}
 	if _, ok := req.URL.Query()["bulk"]; ok {
 		fs.bulkDownload(w, req)
@@ -330,6 +332,7 @@ func (fileS *FileServer) constructDefault(w http.ResponseWriter, relpath string,
 		CLI:             fileS.CLI,
 		Embedded:        fileS.Embedded,
 		EmbeddedContent: e,
+		NoClipboard:     fileS.NoClipboard,
 	}
 
 	files := []string{"static/templates/index.html", "static/templates/header.tmpl", "static/templates/footer.tmpl", "static/templates/scripts_index.tmpl"}

--- a/httpserver/server.go
+++ b/httpserver/server.go
@@ -3,6 +3,7 @@ package httpserver
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/patrickhener/goshs/ws"
 	"io"
 	"log"
 	"net"
@@ -16,7 +17,6 @@ import (
 	"github.com/patrickhener/goshs/ca"
 	"github.com/patrickhener/goshs/clipboard"
 	"github.com/patrickhener/goshs/logger"
-	"github.com/patrickhener/goshs/ws"
 	"golang.org/x/net/webdav"
 	"software.sslmate.com/src/go-pkcs12"
 )
@@ -217,11 +217,13 @@ func (fs *FileServer) Start(what string) {
 	}
 
 	// init clipboard
-	fs.Clipboard = clipboard.New()
+	if !fs.NoClipboard {
+		fs.Clipboard = clipboard.New()
 
-	// init websocket hub
-	fs.Hub = ws.NewHub(fs.Clipboard)
-	go fs.Hub.Run()
+		// init websocket hub
+		fs.Hub = ws.NewHub(fs.Clipboard)
+		go fs.Hub.Run()
+	}
 
 	// Check BasicAuth and use middleware
 	fs.PrintInfoUseBasicAuth(mux, what)

--- a/httpserver/static/templates/index.html
+++ b/httpserver/static/templates/index.html
@@ -226,6 +226,7 @@
         <!-- 6: Clipboard and CLI-->
         <div class="col-xl-6 h-100">
             <!-- Clipboard Heading Row -->
+            {{ if not .NoClipboard }}
             <div class="row">
                 <div class="col mb-2">
                     <h1>Clipboard</h1>
@@ -280,6 +281,7 @@
                     {{ end }}
                 </div>
             </div>
+            {{ end }}
             {{ if .Embedded }}
             <!-- Embedded Heading Row -->
             <div class="row">

--- a/httpserver/structs.go
+++ b/httpserver/structs.go
@@ -14,6 +14,7 @@ type baseTemplate struct {
 	EmbeddedContent *directory
 	CLI             bool
 	Embedded        bool
+	NoClipboard     bool
 }
 
 type directory struct {
@@ -65,6 +66,7 @@ type FileServer struct {
 	Verbose        bool
 	Hub            *ws.Hub
 	Clipboard      *clipboard.Clipboard
+	NoClipboard    bool
 }
 
 type httperror struct {

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ var (
 	leTLSPort   = "443"
 	embedded    = false
 	output      = ""
+	noClipboard = false
 )
 
 // Man page
@@ -66,6 +67,7 @@ Web server options:
   -c,  --cli          Enable cli (only with auth and tls)     (default: false)
   -e,  --embedded     Show embedded files in UI               (default: false)
   -o,  --output       Write output to logfile                 (default: false)
+  -nc, --no-clipboard Disable the clipboard sharing           (default: false)
 
 TLS options:
   -s,   --ssl          Use TLS
@@ -158,6 +160,8 @@ func flags() (*bool, *bool, *bool, *bool) {
 	flag.BoolVar(&embedded, "embedded", embedded, "")
 	flag.StringVar(&output, "o", output, "")
 	flag.StringVar(&output, "output", output, "")
+	flag.BoolVar(&noClipboard, "nc", noClipboard, "")
+	flag.BoolVar(&noClipboard, "no-clipboard", noClipboard, "")
 	updateGoshs := flag.Bool("update", false, "update")
 	hash := flag.Bool("H", false, "hash")
 	hashLong := flag.Bool("hash", false, "hash")
@@ -338,6 +342,7 @@ func main() {
 		Embedded:    embedded,
 		Verbose:     verbose,
 		Version:     goshsVersion,
+		NoClipboard: noClipboard,
 	}
 
 	go server.Start("web")


### PR DESCRIPTION
This PR adds an option to disable the cliboard functionality.

My use case is using goshs as a drop zone, with no other functionnalities. This use case requires disabling the clipboard functionnality (both on the HTML and on the server side).

This PR add a flag to disable the clipboard. When enabled, the clipboard handlers are disabled, and the html does not render the clipboard widget.