### PR TITLE
add range check for delete clipboard entry

### DIFF
--- a/clipboard/clipboard.go
+++ b/clipboard/clipboard.go
@@ -3,6 +3,7 @@ package clipboard
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -49,6 +50,12 @@ func (c *Clipboard) AddEntry(con string) error {
 // DeleteEntry will give the opportunity to delete an entry from the clipboard
 func (c *Clipboard) DeleteEntry(id int) error {
 	entries := c.Entries
+	if id < 0 {
+		return fmt.Errorf("id cannot be negative: %d", id)
+	}
+	if id >= len(entries) {
+		return fmt.Errorf("invalid entry ID: %d", id)
+	}
 	entries = append(entries[:id], entries[id+1:]...)
 	newEntries := reindex(entries)
 	c.Entries = newEntries


### PR DESCRIPTION
# Issue

The current DeleteEntry function assumed that the provided index was always valid. If a client supplied an ID less than 0 or greater than or equal to the length of Entries, the call to `append(entries[:id], entries[id+1:]...)` caused a slice-out-of-range panic, crashing the server.

# Description

The updated implementation validates the input ID before performing the slice operation, and rejects negative IDs and IDs greater than or equal to the length of the current entries. This ensures that malformed or malicious requests cannot terminate the server process.
