### PR TITLE
Bump github.com/google/go-github to v85.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/emersion/go-smtp v0.24.0
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/go-acme/lego/v4 v4.34.0
-	github.com/google/go-github/v42 v42.0.0
+	github.com/google/go-github/v85 v85.0.0
 	github.com/google/uuid v1.6.0
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/hirochachacha/go-smb2 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/go-github/v42 v42.0.0 h1:YNT0FwjPrEysRkLIiKuEfSvBPCGKphW5aS5PxwaoLec=
-github.com/google/go-github/v42 v42.0.0/go.mod h1:jgg/jvyI0YlDOM1/ps6XYh04HNQ3vKf0CVko62/EhRg=
+github.com/google/go-github/v85 v85.0.0 h1:1+TLFX/akTFXK7o9Z9uAloQGufOn4ySa5DItUM1VWT4=
+github.com/google/go-github/v85 v85.0.0/go.mod h1:jYkBnqN+SzR2A2fGKYfbt6DEEQAyxeK0Q2XpPV9ZFsU=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/update/update.go
+++ b/update/update.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v85/github"
 	"github.com/inconshreveable/go-update"
 	"goshs.de/goshs/v2/logger"
 )

--- a/update/update_test.go
+++ b/update/update_test.go
@@ -3,7 +3,7 @@ package update
 import (
 	"testing"
 
-	"github.com/google/go-github/v42/github"
+	"github.com/google/go-github/v85/github"
 	"goshs.de/goshs/v2/goshsversion"
 	"github.com/stretchr/testify/require"
 )
@@ -15,11 +15,13 @@ func TestCheckForUpdates(t *testing.T) {
 
 	oldVersion := "v1.0.0"
 
-	result, _ := CheckForUpdates(oldVersion)
-	require.Equal(t, result, true)
+	result, out := CheckForUpdates(oldVersion)
+	require.NotEmpty(t, out)
+	require.True(t, result)
 
-	result, _ = CheckForUpdates(goshsversion.GoshsVersion)
-	require.Equal(t, result, false)
+	result, out = CheckForUpdates(goshsversion.GoshsVersion)
+	require.Empty(t, out)
+	require.False(t, result)
 }
 
 func TestGetLatestReleaseInvalid(t *testing.T) {


### PR DESCRIPTION
# Description

Bump `github.com/google/go-github` to the latest https://pkg.go.dev/github.com/google/go-github/v85